### PR TITLE
Updates in order to use newest nullsafe version of flutter_map_marker_popup

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -31,11 +31,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-dependency_overrides:
-  flutter_map:
-    git:
-      url: git://github.com/fleaflet/flutter_map.git
-      ref: issues/829-nullsafety
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -36,10 +36,7 @@ dependency_overrides:
     git:
       url: git://github.com/fleaflet/flutter_map.git
       ref: issues/829-nullsafety
-  flutter_map_marker_popup:
-    git:
-      url: git://github.com/bsneider/flutter_map_marker_popup.git
-      ref: nullsafety
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 # The following section is specific to Flutter.

--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -360,7 +360,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
   _unspiderfy() {
     switch (_spiderfyController.status) {
       case AnimationStatus.completed:
-        List<Marker> markersGettingClustered = _spiderfyCluster!.markers
+        var markersGettingClustered = _spiderfyCluster!.markers
             .map((markerNode) => markerNode.marker)
             .toList();
 
@@ -369,7 +369,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
             }));
 
         if (widget.options.popupOptions != null) {
-          widget.options.popupOptions!.popupController!
+          widget.options.popupOptions!.popupController
               .hidePopupIfShowingFor(markersGettingClustered);
         }
         if (widget.options.onMarkersClustered != null) {
@@ -388,7 +388,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
               }));
 
         if (widget.options.popupOptions != null) {
-          widget.options.popupOptions!.popupController!
+          widget.options.popupOptions!.popupController
               .hidePopupIfShowingFor(markersGettingClustered);
         }
         if (widget.options.onMarkersClustered != null) {
@@ -487,7 +487,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
         });
 
         if (widget.options.popupOptions != null) {
-          widget.options.popupOptions!.popupController!
+          widget.options.popupOptions!.popupController
               .hidePopupIfShowingFor(markersGettingClustered);
         }
         if (widget.options.onMarkersClustered != null) {
@@ -673,7 +673,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
           _fitBoundController.isAnimating) return null;
 
       if (widget.options.popupOptions != null) {
-        widget.options.popupOptions!.popupController!
+        widget.options.popupOptions!.popupController
             .togglePopup(marker.marker);
       }
 

--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/plugin_api.dart';
+import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:flutter_map_marker_cluster/src/anim_type.dart';
 import 'package:flutter_map_marker_cluster/src/core/distance_grid.dart';
 import 'package:flutter_map_marker_cluster/src/core/quick_hull.dart';
@@ -544,15 +545,17 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
       layers.addAll(_buildLayer(layer));
     });
 
-    final PopupOptions? popupOptions = widget.options.popupOptions;
+    final popupOptions = widget.options.popupOptions;
     if (popupOptions != null) {
       layers.add(
-        MarkerPopup(
+        PopupLayer(
+          popupBuilder: popupOptions.popupBuilder,
+          popupSnap: popupOptions.popupSnap,
+          popupController: popupOptions.popupController,
+          popupAnimation: popupOptions.popupAnimation,
+          markerRotate: false, // TODO: This should be set once this plugin supports marker rotation.
           mapState: widget.map,
-          popupController: popupOptions.popupController!,
-          snap: popupOptions.popupSnap,
-          popupBuilder: popupOptions.popupBuilder!,
-        ),
+        )
       );
     }
 

--- a/lib/src/marker_cluster_layer_options.dart
+++ b/lib/src/marker_cluster_layer_options.dart
@@ -39,15 +39,26 @@ class AnimationsOptions {
 }
 
 class PopupOptions {
-  final PopupBuilder? popupBuilder;
-  final PopupController? popupController;
+  /// Used to construct the popup.
+  final PopupBuilder popupBuilder;
+
+  /// If a PopupController is provided it can be used to programmatically show
+  /// and hide the popup.
+  final PopupController popupController;
+
+  /// Controls the position of the popup relative to the marker or popup.
   final PopupSnap popupSnap;
 
-  const PopupOptions({
-    this.popupBuilder,
+  /// Allows the use of an animation for showing/hiding popups. Defaults to no
+  /// animation.
+  final PopupAnimation? popupAnimation;
+
+  PopupOptions({
+    required this.popupBuilder,
     this.popupSnap = PopupSnap.markerTop,
-    this.popupController,
-  });
+    PopupController? popupController,
+    this.popupAnimation,
+  }) : popupController = popupController ?? PopupController();
 }
 
 typedef ClusterWidgetBuilder = Widget Function(

--- a/lib/src/marker_cluster_layer_widget.dart
+++ b/lib/src/marker_cluster_layer_widget.dart
@@ -6,11 +6,11 @@ import '../flutter_map_marker_cluster.dart';
 class MarkerClusterLayerWidget extends StatelessWidget {
   final MarkerClusterLayerOptions options;
 
-  MarkerClusterLayerWidget({Key key, @required this.options}) : super(key: key);
+  MarkerClusterLayerWidget({Key? key, required this.options}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final mapState = MapState.of(context);
+    final mapState = MapState.maybeOf(context)!;
     return MarkerClusterLayer(options, mapState, mapState.onMoved);
   }
 }

--- a/lib/src/node/marker_node.dart
+++ b/lib/src/node/marker_node.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:flutter/src/foundation/key.dart';
 import 'package:flutter/src/painting/alignment.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_cluster/src/node/marker_cluster_node.dart';
@@ -10,6 +11,9 @@ class MarkerNode implements Marker {
   MarkerClusterNode? parent;
 
   MarkerNode(this.marker);
+
+  @override
+  Key? get key => marker.key;
 
   @override
   Anchor get anchor => marker.anchor;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   latlong2: ^0.8.0
+  flutter_map_marker_popup: ^0.3.0
 
 dev_dependencies:
   flutter_test:
@@ -24,9 +25,5 @@ dependency_overrides:
       ref: issues/829-nullsafety
   flutter_map_marker_popup:
     git:
-      url: git://github.com/bsneider/flutter_map_marker_popup.git
-      ref: nullsafety
-  flutter_image:
-    git:
-      url: "https://github.com/flutter/flutter_image"
-      ref: null-safety
+      url: git://github.com/rorystephenson/flutter_map_marker_popup.git
+      ref: nullsafety-2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,18 +12,9 @@ dependencies:
   flutter:
     sdk: flutter
   latlong2: ^0.8.0
-  flutter_map_marker_popup: ^0.3.0
+  flutter_map_marker_popup: ^1.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-dependency_overrides:
-  flutter_map:
-    git:
-      url: git://github.com/fleaflet/flutter_map.git
-      ref: issues/829-nullsafety
-  flutter_map_marker_popup:
-    git:
-      url: git://github.com/rorystephenson/flutter_map_marker_popup.git
-      ref: nullsafety-2


### PR DESCRIPTION
Hey again @bsneider ! I've made some big updates to the nullsafe-2 branch for flutter_map_marker_popup which, apart from adding nullsafety, adds many bug fixes and improvements like handling rotation nicely. These changes should make it work with that version!

We still need to wait for flutter_map to publish null safety obviously.

Also it looks like flutter_map_marker_cluster is not supporting rotation yet but that can be tackled in a later PR even.